### PR TITLE
filter on asset_type == combiner

### DIFF
--- a/demos/plant_digitization_example.ipynb
+++ b/demos/plant_digitization_example.ipynb
@@ -64,12 +64,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-05-15T23:19:06.581166Z",
      "start_time": "2024-05-15T23:19:05.820496Z"
     }
    },
+   "outputs": [],
    "source": [
     "# we need geopandas and matplotlib, which are not automatically installed with solartoolbox, so we'll install them if they're not present.\n",
     "try:\n",
@@ -84,45 +86,27 @@
     "    !pip install matplotlib\n",
     "    \n",
     "import pandas as pd"
-   ],
-   "outputs": [],
-   "execution_count": 1
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "Read in the GeoJSON file that we created with QGIS and preview the resulting DataFrame, which uses latitude and longitude coordinates in degrees:"
+   "source": [
+    "Read in the GeoJSON file that we created with QGIS and preview the resulting DataFrame, which uses latitude and longitude coordinates in degrees:"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-05-15T23:19:06.725162Z",
      "start_time": "2024-05-15T23:19:06.583132Z"
     }
    },
-   "source": [
-    "data = gpd.read_file('data/digitized_plant.geojson')\n",
-    "data.head()"
-   ],
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "     id asset_type  asset_name  \\\n",
-       "0  None   combiner  CMB-001-01   \n",
-       "1  None   combiner  CMB-001-02   \n",
-       "2  None   combiner  CMB-001-03   \n",
-       "3  None   combiner  CMB-001-04   \n",
-       "4  None   combiner  CMB-001-05   \n",
-       "\n",
-       "                                            geometry  \n",
-       "0  MULTIPOLYGON (((-83.67303 33.68023, -83.67303 ...  \n",
-       "1  MULTIPOLYGON (((-83.67282 33.68006, -83.67282 ...  \n",
-       "2  MULTIPOLYGON (((-83.67261 33.67975, -83.67261 ...  \n",
-       "3  MULTIPOLYGON (((-83.67240 33.67946, -83.67240 ...  \n",
-       "4  MULTIPOLYGON (((-83.67220 33.67916, -83.67220 ...  "
-      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -187,6 +171,21 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
+      ],
+      "text/plain": [
+       "     id asset_type  asset_name  \\\n",
+       "0  None   combiner  CMB-001-01   \n",
+       "1  None   combiner  CMB-001-02   \n",
+       "2  None   combiner  CMB-001-03   \n",
+       "3  None   combiner  CMB-001-04   \n",
+       "4  None   combiner  CMB-001-05   \n",
+       "\n",
+       "                                            geometry  \n",
+       "0  MULTIPOLYGON (((-83.67303 33.68023, -83.67303 ...  \n",
+       "1  MULTIPOLYGON (((-83.67282 33.68006, -83.67282 ...  \n",
+       "2  MULTIPOLYGON (((-83.67261 33.67975, -83.67261 ...  \n",
+       "3  MULTIPOLYGON (((-83.67240 33.67946, -83.67240 ...  \n",
+       "4  MULTIPOLYGON (((-83.67220 33.67916, -83.67220 ...  "
       ]
      },
      "execution_count": 2,
@@ -194,41 +193,50 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 2
+   "source": [
+    "data = gpd.read_file('data/digitized_plant.geojson')\n",
+    "data.head()"
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "We want to create an anonymized dataset, where the distances are preserved, but the absolute position is relative to the plant. Set the origin latitude and longitude using the minimum latitude and longitude values (Southwest corner of the plant, in this case):"
+   "source": [
+    "We want to create an anonymized dataset, where the distances are preserved, but the absolute position is relative to the plant. Set the origin latitude and longitude using the minimum latitude and longitude values (Southwest corner of the plant, in this case):"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-05-15T23:19:06.741160Z",
      "start_time": "2024-05-15T23:19:06.726131Z"
     }
    },
+   "outputs": [],
    "source": [
     "origin_long = data.geometry.get_coordinates().x.min()\n",
     "origin_lat = data.geometry.get_coordinates().y.min()"
-   ],
-   "outputs": [],
-   "execution_count": 3
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "We'll then project by defining a custom coordinate reference system (CRS) using meters and based on that origin point. The `proj=aeqd` part of the projection creates an [azimuthal equidistant projection](https://proj4.org/en/9.4/operations/projections/aeqd.html), which is useful for measuring distances from a single point."
+   "source": [
+    "We'll then project by defining a custom coordinate reference system (CRS) using meters and based on that origin point. The `proj=aeqd` part of the projection creates an [azimuthal equidistant projection](https://proj4.org/en/9.4/operations/projections/aeqd.html), which is useful for measuring distances from a single point."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-05-15T23:19:06.771149Z",
      "start_time": "2024-05-15T23:19:06.744139Z"
     }
    },
+   "outputs": [],
    "source": [
     "custom_crs = \"+proj=aeqd +lat_0=\" + \\\n",
     "    str(origin_lat) + \" +lon_0=\" + \\\n",
@@ -236,9 +244,7 @@
     "\n",
     "# Convert to custom coordinate system\n",
     "data_utm = data.to_crs(custom_crs)"
-   ],
-   "outputs": [],
-   "execution_count": 4
+   ]
   },
   {
    "cell_type": "markdown",
@@ -249,15 +255,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-05-15T23:19:07.401129Z",
      "start_time": "2024-05-15T23:19:06.774132Z"
     }
    },
-   "source": [
-    "data_utm.loc[data_utm['asset_type']=='combiner'].plot(aspect='equal')"
-   ],
    "outputs": [
     {
      "data": {
@@ -271,53 +275,38 @@
     },
     {
      "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAaAAAAGdCAYAAABU0qcqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAAmYklEQVR4nO3df3DU9b3v8dd3gYSfuzGEZIkSBA+KyI8iaExRjy0ZkkCtVnpHPJwWHAZOaeK9GGsdzlhQb6ep2mmtToTbzinUO6KVuaIXTqVDA4RaA2rUg6JyhJsj0LAJQpMNUUKS/dw/SL5kk92QDUk+Sfb5mNnJ7vfz+X6+7+9nd/PaH9/ddYwxRgAA9DGP7QIAAPGJAAIAWEEAAQCsIIAAAFYQQAAAKwggAIAVBBAAwAoCCABgxVDbBXRHKBRSZWWlxowZI8dxbJcDAGhhjFFdXZ3S09Pl8XT+HGdABlBlZaUmTJhguwwAQBTHjx/XVVdd1WmfmAKoqKhIr776qj799FONGDFCX//61/Xkk0/quuuuc/vccccdKi0tDVvvX/7lX7Rx40b38rFjx7R69Wrt2bNHo0eP1rJly1RUVKShQ7tWzpgxYyRd2EGv1xvLLgAAelEwGNSECRPc/9OdiSmASktLlZ+fr5tuuklNTU3613/9Vy1YsEAff/yxRo0a5fZbuXKlnnjiCffyyJEj3fPNzc1atGiR/H6/3nrrLZ08eVLf//73NWzYMP3sZz/rUh2tL7t5vV4CCAD6oa68PeJczpeRnjp1SqmpqSotLdXtt98u6cIzoK997Wt65plnIq7zxhtv6Fvf+pYqKyuVlpYmSdq4caMeeeQRnTp1SgkJCZfcbjAYlM/nU21tLQEEAP1ILP+fL+souNraWklScnJy2PIXX3xRKSkpmj59utauXasvv/zSbSsrK9OMGTPc8JGknJwcBYNBHTp06HLKAQAMIN0+CCEUCmnNmjWaN2+epk+f7i7/p3/6J02cOFHp6ek6ePCgHnnkER0+fFivvvqqJCkQCISFjyT3ciAQiLithoYGNTQ0uJeDwWB3ywYA9BPdDqD8/Hx99NFHevPNN8OWr1q1yj0/Y8YMjR8/XvPnz9fRo0d1zTXXdGtbRUVFevzxx7tbKgCgH+rWS3AFBQXasWOH9uzZc8nD7DIzMyVJR44ckST5/X5VVVWF9Wm97Pf7I46xdu1a1dbWuqfjx493p2wAQD8SUwAZY1RQUKBt27Zp9+7dmjRp0iXX+eCDDyRJ48ePlyRlZWXpww8/VHV1tdtn165d8nq9mjZtWsQxEhMT3SPeOPINAAaHmF6Cy8/P15YtW/T6669rzJgx7ns2Pp9PI0aM0NGjR7VlyxYtXLhQY8eO1cGDB/Xggw/q9ttv18yZMyVJCxYs0LRp0/S9731PTz31lAKBgB599FHl5+crMTGx5/cQANAvxXQYdrTjujdt2qTly5fr+PHj+ud//md99NFHqq+v14QJE/Sd73xHjz76aNizls8//1yrV6/W3r17NWrUKC1btkw///nPu/xBVA7DBoD+KZb/z5f1OSBbCCAA6J/67HNAAAB0FwEEALCCAAIAWEEAAQCsGJC/B4T+5+k/fSpJ8jiOHF04YtJxLl72eC4cQRm2rKWP416+uJ7Tro/HkRy1a/OEL2vtc2Gci/3ctojjXrisdrW2rpc6JlETkke2310APYAAQo8o3nPUdgm9YvnXr9Zj377BdhnAoMRLcAAAKwggAIAVBBAAwAoCCABgBQEEALCCAAIAWEEAAQCsIIAAAFYQQAAAKwggAIAVBBAAwAoCCABgBQEEALCCAAIAWEEAAQCsIIAAAFbwg3RxrDlk1Ngcajl18XxTSE2hkM63Ow8AsSKABqmHXvkP/ceJGjW1BMf55lCH8yFyA4BFBNAg9fHJoI5Un7VdBgBExXtAg9TZhkbbJQBApwigQaq+odl2CQDQKQJokDp7rsl2CQDQKQJoEGpoatb55pDtMgCgUxyEMAglDPHo8E9zZVqOcjNGMjItfyVjTMtfSZ20XTjX2ifKOF3ZRss4JtI4bc53a5z29XZWq7svbcaJsp3W5RPHjuzZKweAiwAahBzHUeLQIbbLAIBOEUB96Df7jqr2K45OQ0fpSSO0NHOi7TKAPkUA9aEXyj7Xib9/ZbsM9EM3ZiQRQIg7HIQAALCCAAIAWEEAAQCsIIAAAFYQQAAAKwggAIAVBBAAwAoCCABgBQEEALCCAAIAWEEAAQCsIIAAAFYQQAAAKwggAIAVBBAAwAoCCABgRVz/IN1fj3yh/6yqU3PIKGSMmkNSyBiFQkbNbf52urx1mbu8ZVnLcmNaz0un6hps7zIA9BtxHUD/p/yEXn3/b7bLAIC4FNcvwTUbY7sEAIhb8R1AIQIIAGwhgAAAVhBAAAAr4jqAQrwHBADWxHUA8QwIAOyJ6wBqIoAAwJq4DiBeggMAe2IKoKKiIt10000aM2aMUlNTdffdd+vw4cNhfc6dO6f8/HyNHTtWo0eP1uLFi1VVVRXW59ixY1q0aJFGjhyp1NRUPfzww2pqarr8vYkRL8EBgD0xBVBpaany8/O1f/9+7dq1S42NjVqwYIHq6+vdPg8++KC2b9+urVu3qrS0VJWVlbrnnnvc9ubmZi1atEjnz5/XW2+9pd///vfavHmz1q1b13N71UWhUJ9vEgDQwjGm+69DnTp1SqmpqSotLdXtt9+u2tpajRs3Tlu2bNF3v/tdSdKnn36q66+/XmVlZbrlllv0xhtv6Fvf+pYqKyuVlpYmSdq4caMeeeQRnTp1SgkJCZfcbjAYlM/nU21trbxeb3fL1z3P/1XvHavp9vpAT7kxI0mv/nCe7TKAyxbL/+fLeg+otrZWkpScnCxJKi8vV2Njo7Kzs90+U6dOVUZGhsrKyiRJZWVlmjFjhhs+kpSTk6NgMKhDhw5F3E5DQ4OCwWDYqSc08wocAFjT7QAKhUJas2aN5s2bp+nTp0uSAoGAEhISlJSUFNY3LS1NgUDA7dM2fFrbW9siKSoqks/nc08TJkzobtnt9oEEAgBbuh1A+fn5+uijj/Tyyy/3ZD0RrV27VrW1te7p+PHjPTIuByEAgD3d+jmGgoIC7dixQ/v27dNVV13lLvf7/Tp//rxqamrCngVVVVXJ7/e7fd5+++2w8VqPkmvt015iYqISExO7U2qnCCAAsCemZ0DGGBUUFGjbtm3avXu3Jk2aFNY+Z84cDRs2TCUlJe6yw4cP69ixY8rKypIkZWVl6cMPP1R1dbXbZ9euXfJ6vZo2bdrl7EvM+DkGALAnpmdA+fn52rJli15//XWNGTPGfc/G5/NpxIgR8vl8WrFihQoLC5WcnCyv16sHHnhAWVlZuuWWWyRJCxYs0LRp0/S9731PTz31lAKBgB599FHl5+f3yrOczvAeEADYE1MAbdiwQZJ0xx13hC3ftGmTli9fLkn61a9+JY/Ho8WLF6uhoUE5OTl6/vnn3b5DhgzRjh07tHr1amVlZWnUqFFatmyZnnjiicvbk27gq3gAwJ6YAqgrHxkaPny4iouLVVxcHLXPxIkT9cc//jGWTfcK3gMCAHv4LjgAgBVxHUA8AwIAewggAIAV3foc0GAxedwojR2dIGMkowvvcRlJanf5Qru58LclsyK26WK7wpa16duVbbjtkccAgMEgrgNo6w++bruEy2JMlJBrCS4pUkC2CbJLhJxpScnIQdvFbbQL5w5B3tVa24/Tbn8j1Xlhrfahf3H7Xa5VFw/AiTy/UbYRYRxFeDBijDRuTN9+BAHoD+I6gAY6x3HkOO4lm6UAQMzi+j0gAIA9BBAAwIq4fglu33+e0tpXP7RdBtDnfvv9uZqW3v0fcwR6QlwH0LnGZv2t5ivbZQB9rrGZ36OHfbwEBwCwggACAFhBAAEArCCAAABWEEAAACsIIACAFQQQAMAKAggAYAUBBACwggACAFhBAAEArCCAAABWEEAAACsIIACAFQQQAMAKAggAYAUBBACwggACAFhBAAEArCCAAABWEEAAACsIIACAFQQQAMAKAggAYAUBBACwggACAFhBAAEArCCAAABWEEAAACsIIACAFQQQAMAKAggAYAUBBACwggACAFhBAAEArCCAAABWEEAAACsIIACAFQQQAMAKAggAYMVQ2wXYNCVtjB7JnWq7DKDPjfcNt10CEN8BNClllFbfcY3tMgAgLsV1AEnSmfrzkiRHkuOo5bwjOW0vS07LhdZ+jlouOxfHal3efj2nbXvbFQAgjsV9AN34P3dZ2/aFwGo93y6odLGxfThGXC9SWDqRw9MdKWycyOEZVmu7Gtr2azNsh9oirRdxn9sF+8Ux248TZb7abD9irU7kGtrOTbTa1WGf29Xa/sFL1DkI36ai7HOH66PNlXzxeg3fx7bbVLRx2q7X4bYT+TYRVluE21LE9Voa//HacZp+pU9AJHEfQDYZI5m2F8Jb+7gaoOd5hw8lgBAVR8EBAKwggAAAVhBAAAArYg6gffv26c4771R6erocx9Frr70W1r58+fILb262OeXm5ob1OXPmjJYuXSqv16ukpCStWLFCZ8+evawdAQAMLDEHUH19vWbNmqXi4uKofXJzc3Xy5En39NJLL4W1L126VIcOHdKuXbu0Y8cO7du3T6tWrYq9egDAgBXzUXB5eXnKy8vrtE9iYqL8fn/Etk8++UQ7d+7UO++8o7lz50qSnnvuOS1cuFC/+MUvlJ6eHmtJAIABqFfeA9q7d69SU1N13XXXafXq1Tp9+rTbVlZWpqSkJDd8JCk7O1sej0cHDhyIOF5DQ4OCwWDYCQAwsPV4AOXm5uqFF15QSUmJnnzySZWWliovL0/Nzc2SpEAgoNTU1LB1hg4dquTkZAUCgYhjFhUVyefzuacJEyb0dNkAgD7W4x9EXbJkiXt+xowZmjlzpq655hrt3btX8+fP79aYa9euVWFhoXs5GAwSQgAwwPX6YdiTJ09WSkqKjhw5Ikny+/2qrq4O69PU1KQzZ85Efd8oMTFRXq837AQAGNh6PYBOnDih06dPa/z48ZKkrKws1dTUqLy83O2ze/duhUIhZWZm9nY5AIB+IuaX4M6ePes+m5GkiooKffDBB0pOTlZycrIef/xxLV68WH6/X0ePHtWPf/xj/cM//INycnIkSddff71yc3O1cuVKbdy4UY2NjSooKNCSJUs4Ag4A4kjMz4DeffddzZ49W7Nnz5YkFRYWavbs2Vq3bp2GDBmigwcP6tvf/rauvfZarVixQnPmzNFf/vIXJSYmumO8+OKLmjp1qubPn6+FCxfq1ltv1W9+85ue2ysAQL8X8zOgO+64Q6bDNzdf9Kc//emSYyQnJ2vLli2xbhoAMIjwXXAAACsIIACAFQQQAMAKAggAYAUBBACwggACAFhBAAEArCCAAABWEEAAACsIIACAFQQQAMAKAggAYAUBBACwggACAFhBAAEArCCAAABWEEAAACsIIACAFQQQAMAKAggAYAUBBACwggACAFhBAAEArCCAAABWEEAAACsIIACAFQQQAMCKobYLsO3B7GttlwAMWjOvSrJdAvqxuA+g/5E9xXYJABCX4j6AzjU2qylk3MtOmzanzQWnTUvb5W21Xx5tnfBtOFGWR+4DAINF3AdQwZb39edPqmyX0W2XFWyKvHK0/u3XiXXb0bcRPdxj3Sd1qb62y8M32JV9itq/iw9YemyuotXRyT6FL+/Kg5/I40abp/aN0WuMsY72W4kw1uN33aCpfm/7atCPxX0ADXTGtDkfrSH62j1cDWBP3bkm2yUgRhwFBwCwggACAFhBAAEArCCAAABWEEAAACsIIACAFQQQAMAKAggAYAUBBACwggACAFhBAAEArCCAAABWEEAAACsIIACAFQQQAMAKAggAYAUBBACwggACAFhBAAEArCCAAABWEEAAACsIIACAFUNtF2BbRvJITb/Sa7sMAJdpxLAhtktAjOI+gNbdOc12CQAQl3gJDgBgRdw/A5Kkfz94UtV15+RIchxHjiM5kuQ4LcskT5vzji50aO3vcS4ud5wLYzpR1pUujt9+3bZjtl9XbcZvv277MduuK4XX1nq+s3U9Ttv9CB+zdd1I9bSuK3c7HddtW0PEPq0bBjDoEUCSNv21Qu9+/nfbZaDF5YRXpOVSxwcJrX0kyeOJPKYiPPBo/wCj/bpde9DSEuSeyGN2/qAlfN3YHrS0fXDRccyoD1rarBtpzIvXTYTrq8N105V1I1yXUdZtvY7Gjk7QN65L7cFbIfpCzAG0b98+Pf300yovL9fJkye1bds23X333W67MUbr16/Xb3/7W9XU1GjevHnasGGDpkyZ4vY5c+aMHnjgAW3fvl0ej0eLFy/Wr3/9a40ePbpHdgoDmzGSaT1zcamlajAQ3JiRRAANQDG/B1RfX69Zs2apuLg4YvtTTz2lZ599Vhs3btSBAwc0atQo5eTk6Ny5c26fpUuX6tChQ9q1a5d27Nihffv2adWqVd3fCwDAgBPzM6C8vDzl5eVFbDPG6JlnntGjjz6qu+66S5L0wgsvKC0tTa+99pqWLFmiTz75RDt37tQ777yjuXPnSpKee+45LVy4UL/4xS+Unp5+GbsDABgoevQouIqKCgUCAWVnZ7vLfD6fMjMzVVZWJkkqKytTUlKSGz6SlJ2dLY/HowMHDkQct6GhQcFgMOwEABjYejSAAoGAJCktLS1seVpamtsWCASUmhr+Wu3QoUOVnJzs9mmvqKhIPp/PPU2YMKEnywYAWDAgPge0du1a1dbWuqfjx4/bLgkAcJl6NID8fr8kqaqqKmx5VVWV2+b3+1VdXR3W3tTUpDNnzrh92ktMTJTX6w07AQAGth4NoEmTJsnv96ukpMRdFgwGdeDAAWVlZUmSsrKyVFNTo/LycrfP7t27FQqFlJmZ2ZPlAAD6sZiPgjt79qyOHDniXq6oqNAHH3yg5ORkZWRkaM2aNfrpT3+qKVOmaNKkSfrJT36i9PR097NC119/vXJzc7Vy5Upt3LhRjY2NKigo0JIlSzgCDgDiSMwB9O677+ob3/iGe7mwsFCStGzZMm3evFk//vGPVV9fr1WrVqmmpka33nqrdu7cqeHDh7vrvPjiiyooKND8+fPdD6I+++yzPbA7AICBwjHGDLiPmAeDQfl8PtXW1vbI+0Hf3fAWX8UDDGA3ZiTp1R/Os10GFNv/5wFxFBwAYPAhgAAAVhBAAAArCCAAgBUEEADACgIIAGAFAQQAsIIAAgBYQQABAKwggAAAVhBAAAArYv4y0sFoUsoofdXYbLsMAN00KWW07RLQDQSQpKf/2yzbJQBA3OElOACAFQQQAMCKuH4J7q2jX+iJ7R+HLXMcR457vt1fOW3OX+zUoX9nY+lip0htkbbZ9nLruOHbCd9ma9vFdcLHcBR9/Atjhe+IE2Wb0doUaX+6sK/qav92+9q+X8c5Ce/vtKux4/5EH0sR577jGG5b2yuuK/0jXN+ttXc69126XXYyN21ukJ3dlrp6u4x6+wpbJ1JbhPmNcN/prH9r345z0tncR7/tRbpdehxHsyYkCZcnrgPo7LkmfRqos10GgAFmqMfRkZ8ttF3GgMdLcAAAKwggAIAVBBAAwAoCCABgBQEEALCCAAIAWEEAAQCsIIAAAFYQQAAAKwggAIAVBBAAwAoCCABgBQEEALCCAAIAWEEAAQCsIIAAAFYQQAAAKwggAIAVBBAAwAoCCABgBQEEALCCAAIAWEEAAQCsIIAAAFYQQAAAKwggAIAVBBAAwAoCCABgBQEEALCCAAIAWDHUdgE2pYxJ1DenptouA8AA43Ec2yUMCnEdQDdmXKHfLb/JdhkAEJd4CQ4AYEVcPwOqb2hSY3NIkuSozVPqtmedDovktCwMX9baz+mwTDH0c9xlToRlHWsAgIEqrgPosf97SFvLT9guo8d0FpZtl4cHXseVOusXKSzbbicsFjsL726EriKEdlcfBESbk/b9ujNOl/c52vYizG2kWiM/EIlea9g2L3k76OL2Orm9XKqey9nn8LE79o08t92/vURrj/X6vdR9UZeYE0fSlVeM0JrsazUYxXUADTbGtPyNtDD6Wr1UDYCeMP1K76ANIN4DAgBYQQABAKwggAAAVhBAAAArCCAAgBU9HkCPPfaYHMcJO02dOtVtP3funPLz8zV27FiNHj1aixcvVlVVVU+XAQDo53rlGdANN9ygkydPuqc333zTbXvwwQe1fft2bd26VaWlpaqsrNQ999zTG2UAAPqxXvkc0NChQ+X3+zssr62t1b/9279py5Yt+uY3vylJ2rRpk66//nrt379ft9xyS2+UAwDoh3rlGdBnn32m9PR0TZ48WUuXLtWxY8ckSeXl5WpsbFR2drbbd+rUqcrIyFBZWVnU8RoaGhQMBsNOAICBrccDKDMzU5s3b9bOnTu1YcMGVVRU6LbbblNdXZ0CgYASEhKUlJQUtk5aWpoCgUDUMYuKiuTz+dzThAkTerpsAEAf6/GX4PLy8tzzM2fOVGZmpiZOnKhXXnlFI0aM6NaYa9euVWFhoXs5GAwSQgAwwPX6YdhJSUm69tprdeTIEfn9fp0/f141NTVhfaqqqiK+Z9QqMTFRXq837AQAGNh6PYDOnj2ro0ePavz48ZozZ46GDRumkpISt/3w4cM6duyYsrKyersUAEA/0uMvwf3oRz/SnXfeqYkTJ6qyslLr16/XkCFDdN9998nn82nFihUqLCxUcnKyvF6vHnjgAWVlZXEEHADEmR4PoBMnTui+++7T6dOnNW7cON16663av3+/xo0bJ0n61a9+JY/Ho8WLF6uhoUE5OTl6/vnne7oMAEA/1+MB9PLLL3faPnz4cBUXF6u4uLinNw0AGED4LjgAgBUEEADACgIIAGAFAQQAsIIAAgBYQQABAKzolZ9jGChGJAyRd3hcTwGAfm5UwuD9H+UYY4ztImIVDAbl8/lUW1vL98IBQD8Sy//nwRutl3Di71/qVF2DhngceZyWk0ca4jjytCwb0rLM4zga4nHkOBfaL5x3Wta92H5hHMlxHNu7BwD9XtwG0P8u+1z/a9//65WxW0PJ0xJQYaHWJqjc863B19JviNMSdp62yxTW3hqMEcd0AzTyOmGhG7aOWrZ9oU/E0HXUbl/ajRlxn8NrjRTk7fe5/ToR63McOWFzFz6PAPq3uA2g3hQyUsiYC2dgTduADAtMN5C7GLodwv5SoauwkI82ZtvthtXVxSCPtE7bPl0Oco9aHly0qbVd/R33WW1eJYi8z7wagEshgDBoNYeMmiVJPBCwpTV4uxpareHX4VWAqKEb3idiEHYIXbV5Rh/pQUmUIA97af7iti6GdxeDvF39UV8ZaVk+YtgQZYwdafuq7BUEEIBeY4zUZIwko5ZHA4jRDele/ft/v812Gb2CzwEBAKwggAAAVhBAAAArCCAAgBUEEADACgIIAGAFAQQAsIIAAgBYQQABAKwggAAAVhBAAAArCCAAgBUEEADACgIIAGAFAQQAsIIAAgBYQQABAKwggAAAVhBAAAArCCAAgBUEEADAiqG2C7AlZ7pfE8eOsl0GAHTqipHDbJfQa+I2gG7MuEI3ZlxhuwwAiFtxG0CS9HbFGf3ls1OSJGMuLje6eKHt8gttitjWdp0oZ2XM5Y3bfp2I40YZp7Oxoq8Tpf9ljtuVubqwzqX3K+r8hhcYedvtx+rCvHdlrrpTY1f6t9elemPcp/YLujYPXb39RW6M9bbf+X0n8nzFft22uz6jXIj9uu3a7S+8z2WOG2V5tPv3rVNS9OslsyMX08PiOoDeO/Z3Pbf7iO0yAKDfqDvX1Gfb4iAEAIAVBBAAwAoCCABgBQEEALCCAAIAWEEAAQCsIIAAAFYQQAAAKwggAIAVBBAAwAoCCABgBQEEALCCAAIAWEEAAQCsIIAAAFYQQAAAKwggAIAVBBAAwAoCCABgBQEEALDCagAVFxfr6quv1vDhw5WZmam3337bZjkAgD5kLYD+8Ic/qLCwUOvXr9d7772nWbNmKScnR9XV1bZKAgD0IWsB9Mtf/lIrV67U/fffr2nTpmnjxo0aOXKkfve739kqCQDQh6wE0Pnz51VeXq7s7OyLhXg8ys7OVllZWYf+DQ0NCgaDYScAwMA21MZGv/jiCzU3NystLS1seVpamj799NMO/YuKivT444/3eB03XZ2sh3Ou6/FxAWCgmjh2ZJ9ty0oAxWrt2rUqLCx0LweDQU2YMOGyx50z8QrNmXjFZY8DAIidlQBKSUnRkCFDVFVVFba8qqpKfr+/Q//ExEQlJib2VXkAgD5g5T2ghIQEzZkzRyUlJe6yUCikkpISZWVl2SgJANDHrL0EV1hYqGXLlmnu3Lm6+eab9cwzz6i+vl7333+/rZIAAH3IWgDde++9OnXqlNatW6dAIKCvfe1r2rlzZ4cDEwAAg5NjjDG2i4hVMBiUz+dTbW2tvF6v7XIAAC1i+f/Md8EBAKwggAAAVhBAAAArCCAAgBUEEADACgIIAGAFAQQAsIIAAgBYQQABAKwYED/H0F7rlzfww3QA0L+0/l/uypfsDMgAqqurk6Qe+U0gAEDPq6urk8/n67TPgPwuuFAopMrKSo0ZM0aO48S8fusP2h0/fpzvkmuDeemIOYmMeemIObnAGKO6ujqlp6fL4+n8XZ4B+QzI4/HoqquuuuxxvF5vXN9QomFeOmJOImNeOmJOdMlnPq04CAEAYAUBBACwIi4DKDExUevXr1diYqLtUvoV5qUj5iQy5qUj5iR2A/IgBADAwBeXz4AAAPYRQAAAKwggAIAVBBAAwIq4DKDi4mJdffXVGj58uDIzM/X222/bLqnPPPbYY3IcJ+w0depUt/3cuXPKz8/X2LFjNXr0aC1evFhVVVUWK+4d+/bt05133qn09HQ5jqPXXnstrN0Yo3Xr1mn8+PEaMWKEsrOz9dlnn4X1OXPmjJYuXSqv16ukpCStWLFCZ8+e7cO96FmXmpPly5d3uO3k5uaG9Rlsc1JUVKSbbrpJY8aMUWpqqu6++24dPnw4rE9X7jPHjh3TokWLNHLkSKWmpurhhx9WU1NTX+5KvxR3AfSHP/xBhYWFWr9+vd577z3NmjVLOTk5qq6utl1an7nhhht08uRJ9/Tmm2+6bQ8++KC2b9+urVu3qrS0VJWVlbrnnnssVts76uvrNWvWLBUXF0dsf+qpp/Tss89q48aNOnDggEaNGqWcnBydO3fO7bN06VIdOnRIu3bt0o4dO7Rv3z6tWrWqr3ahx11qTiQpNzc37Lbz0ksvhbUPtjkpLS1Vfn6+9u/fr127dqmxsVELFixQfX292+dS95nm5mYtWrRI58+f11tvvaXf//732rx5s9atW2djl/oXE2duvvlmk5+f715ubm426enppqioyGJVfWf9+vVm1qxZEdtqamrMsGHDzNatW91ln3zyiZFkysrK+qjCvifJbNu2zb0cCoWM3+83Tz/9tLuspqbGJCYmmpdeeskYY8zHH39sJJl33nnH7fPGG28Yx3HM3/72tz6rvbe0nxNjjFm2bJm56667oq4z2OfEGGOqq6uNJFNaWmqM6dp95o9//KPxeDwmEAi4fTZs2GC8Xq9paGjo2x3oZ+LqGdD58+dVXl6u7Oxsd5nH41F2drbKysosVta3PvvsM6Wnp2vy5MlaunSpjh07JkkqLy9XY2Nj2PxMnTpVGRkZcTU/FRUVCgQCYfPg8/mUmZnpzkNZWZmSkpI0d+5ct092drY8Ho8OHDjQ5zX3lb179yo1NVXXXXedVq9erdOnT7tt8TAntbW1kqTk5GRJXbvPlJWVacaMGUpLS3P75OTkKBgM6tChQ31Yff8TVwH0xRdfqLm5OeyGIElpaWkKBAKWqupbmZmZ2rx5s3bu3KkNGzaooqJCt912m+rq6hQIBJSQkKCkpKSwdeJpfiS5+9rZ7SQQCCg1NTWsfejQoUpOTh60c5Wbm6sXXnhBJSUlevLJJ1VaWqq8vDw1NzdLGvxzEgqFtGbNGs2bN0/Tp0+XpC7dZwKBQMTbUmtbPBuQ34aN7svLy3PPz5w5U5mZmZo4caJeeeUVjRgxwmJl6O+WLFninp8xY4Zmzpypa665Rnv37tX8+fMtVtY38vPz9dFHH4W9Z4rLE1fPgFJSUjRkyJAOR6hUVVXJ7/dbqsqupKQkXXvttTpy5Ij8fr/Onz+vmpqasD7xNj+t+9rZ7cTv93c4cKWpqUlnzpyJm7maPHmyUlJSdOTIEUmDe04KCgq0Y8cO7dmzJ+ynYLpyn/H7/RFvS61t8SyuAighIUFz5sxRSUmJuywUCqmkpERZWVkWK7Pn7NmzOnr0qMaPH685c+Zo2LBhYfNz+PBhHTt2LK7mZ9KkSfL7/WHzEAwGdeDAAXcesrKyVFNTo/LycrfP7t27FQqFlJmZ2ec123DixAmdPn1a48ePlzQ458QYo4KCAm3btk27d+/WpEmTwtq7cp/JysrShx9+GBbOu3btktfr1bRp0/pmR/or20dB9LWXX37ZJCYmms2bN5uPP/7YrFq1yiQlJYUdoTKYPfTQQ2bv3r2moqLC/PWvfzXZ2dkmJSXFVFdXG2OM+cEPfmAyMjLM7t27zbvvvmuysrJMVlaW5ap7Xl1dnXn//ffN+++/bySZX/7yl+b99983n3/+uTHGmJ///OcmKSnJvP766+bgwYPmrrvuMpMmTTJfffWVO0Zubq6ZPXu2OXDggHnzzTfNlClTzH333Wdrly5bZ3NSV1dnfvSjH5mysjJTUVFh/vznP5sbb7zRTJkyxZw7d84dY7DNyerVq43P5zN79+41J0+edE9ffvml2+dS95mmpiYzffp0s2DBAvPBBx+YnTt3mnHjxpm1a9fa2KV+Je4CyBhjnnvuOZORkWESEhLMzTffbPbv32+7pD5z7733mvHjx5uEhARz5ZVXmnvvvdccOXLEbf/qq6/MD3/4Q3PFFVeYkSNHmu985zvm5MmTFivuHXv27DGSOpyWLVtmjLlwKPZPfvITk5aWZhITE838+fPN4cOHw8Y4ffq0ue+++8zo0aON1+s1999/v6mrq7OwNz2jszn58ssvzYIFC8y4cePMsGHDzMSJE83KlSs7PHAbbHMSaT4kmU2bNrl9unKf+a//+i+Tl5dnRowYYVJSUsxDDz1kGhsb+3hv+h9+jgEAYEVcvQcEAOg/CCAAgBUEEADACgIIAGAFAQQAsIIAAgBYQQABAKwggAAAVhBAAAArCCAAgBUEEADACgIIAGDF/wcNtM4g4ZonawAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
-      ],
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAaAAAAGdCAYAAABU0qcqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAmYklEQVR4nO3df3DU9b3v8dd3gYSfuzGEZIkSBA+KyI8iaExRjy0ZkkCtVnpHPJwWHAZOaeK9GGsdzlhQb6ep2mmtToTbzinUO6KVuaIXTqVDA4RaA2rUg6JyhJsj0LAJQpMNUUKS/dw/SL5kk92QDUk+Sfb5mNnJ7vfz+X6+7+9nd/PaH9/ddYwxRgAA9DGP7QIAAPGJAAIAWEEAAQCsIIAAAFYQQAAAKwggAIAVBBAAwAoCCABgxVDbBXRHKBRSZWWlxowZI8dxbJcDAGhhjFFdXZ3S09Pl8XT+HGdABlBlZaUmTJhguwwAQBTHjx/XVVdd1WmfmAKoqKhIr776qj799FONGDFCX//61/Xkk0/quuuuc/vccccdKi0tDVvvX/7lX7Rx40b38rFjx7R69Wrt2bNHo0eP1rJly1RUVKShQ7tWzpgxYyRd2EGv1xvLLgAAelEwGNSECRPc/9OdiSmASktLlZ+fr5tuuklNTU3613/9Vy1YsEAff/yxRo0a5fZbuXKlnnjiCffyyJEj3fPNzc1atGiR/H6/3nrrLZ08eVLf//73NWzYMP3sZz/rUh2tL7t5vV4CCAD6oa68PeJczpeRnjp1SqmpqSotLdXtt98u6cIzoK997Wt65plnIq7zxhtv6Fvf+pYqKyuVlpYmSdq4caMeeeQRnTp1SgkJCZfcbjAYlM/nU21tLQEEAP1ILP+fL+souNraWklScnJy2PIXX3xRKSkpmj59utauXasvv/zSbSsrK9OMGTPc8JGknJwcBYNBHTp06HLKAQAMIN0+CCEUCmnNmjWaN2+epk+f7i7/p3/6J02cOFHp6ek6ePCgHnnkER0+fFivvvqqJCkQCISFjyT3ciAQiLithoYGNTQ0uJeDwWB3ywYA9BPdDqD8/Hx99NFHevPNN8OWr1q1yj0/Y8YMjR8/XvPnz9fRo0d1zTXXdGtbRUVFevzxx7tbKgCgH+rWS3AFBQXasWOH9uzZc8nD7DIzMyVJR44ckST5/X5VVVWF9Wm97Pf7I46xdu1a1dbWuqfjx493p2wAQD8SUwAZY1RQUKBt27Zp9+7dmjRp0iXX+eCDDyRJ48ePlyRlZWXpww8/VHV1tdtn165d8nq9mjZtWsQxEhMT3SPeOPINAAaHmF6Cy8/P15YtW/T6669rzJgx7ns2Pp9PI0aM0NGjR7VlyxYtXLhQY8eO1cGDB/Xggw/q9ttv18yZMyVJCxYs0LRp0/S9731PTz31lAKBgB599FHl5+crMTGx5/cQANAvxXQYdrTjujdt2qTly5fr+PHj+ud//md99NFHqq+v14QJE/Sd73xHjz76aNizls8//1yrV6/W3r17NWrUKC1btkw///nPu/xBVA7DBoD+KZb/z5f1OSBbCCAA6J/67HNAAAB0FwEEALCCAAIAWEEAAQCsGJC/B4T+5+k/fSpJ8jiOHF04YtJxLl72eC4cQRm2rKWP416+uJ7Tro/HkRy1a/OEL2vtc2Gci/3ctojjXrisdrW2rpc6JlETkke2310APYAAQo8o3nPUdgm9YvnXr9Zj377BdhnAoMRLcAAAKwggAIAVBBAAwAoCCABgBQEEALCCAAIAWEEAAQCsIIAAAFYQQAAAKwggAIAVBBAAwAoCCABgBQEEALCCAAIAWEEAAQCsIIAAAFbwg3RxrDlk1Ngcajl18XxTSE2hkM63Ow8AsSKABqmHXvkP/ceJGjW1BMf55lCH8yFyA4BFBNAg9fHJoI5Un7VdBgBExXtAg9TZhkbbJQBApwigQaq+odl2CQDQKQJokDp7rsl2CQDQKQJoEGpoatb55pDtMgCgUxyEMAglDPHo8E9zZVqOcjNGMjItfyVjTMtfSZ20XTjX2ifKOF3ZRss4JtI4bc53a5z29XZWq7svbcaJsp3W5RPHjuzZKweAiwAahBzHUeLQIbbLAIBOEUB96Df7jqr2K45OQ0fpSSO0NHOi7TKAPkUA9aEXyj7Xib9/ZbsM9EM3ZiQRQIg7HIQAALCCAAIAWEEAAQCsIIAAAFYQQAAAKwggAIAVBBAAwAoCCABgBQEEALCCAAIAWEEAAQCsIIAAAFYQQAAAKwggAIAVBBAAwAoCCABgRVz/IN1fj3yh/6yqU3PIKGSMmkNSyBiFQkbNbf52urx1mbu8ZVnLcmNaz0un6hps7zIA9BtxHUD/p/yEXn3/b7bLAIC4FNcvwTUbY7sEAIhb8R1AIQIIAGwhgAAAVhBAAAAr4jqAQrwHBADWxHUA8QwIAOyJ6wBqIoAAwJq4DiBeggMAe2IKoKKiIt10000aM2aMUlNTdffdd+vw4cNhfc6dO6f8/HyNHTtWo0eP1uLFi1VVVRXW59ixY1q0aJFGjhyp1NRUPfzww2pqarr8vYkRL8EBgD0xBVBpaany8/O1f/9+7dq1S42NjVqwYIHq6+vdPg8++KC2b9+urVu3qrS0VJWVlbrnnnvc9ubmZi1atEjnz5/XW2+9pd///vfavHmz1q1b13N71UWhUJ9vEgDQwjGm+69DnTp1SqmpqSotLdXtt9+u2tpajRs3Tlu2bNF3v/tdSdKnn36q66+/XmVlZbrlllv0xhtv6Fvf+pYqKyuVlpYmSdq4caMeeeQRnTp1SgkJCZfcbjAYlM/nU21trbxeb3fL1z3P/1XvHavp9vpAT7kxI0mv/nCe7TKAyxbL/+fLeg+otrZWkpScnCxJKi8vV2Njo7Kzs90+U6dOVUZGhsrKyiRJZWVlmjFjhhs+kpSTk6NgMKhDhw5F3E5DQ4OCwWDYqSc08wocAFjT7QAKhUJas2aN5s2bp+nTp0uSAoGAEhISlJSUFNY3LS1NgUDA7dM2fFrbW9siKSoqks/nc08TJkzobtnt9oEEAgBbuh1A+fn5+uijj/Tyyy/3ZD0RrV27VrW1te7p+PHjPTIuByEAgD3d+jmGgoIC7dixQ/v27dNVV13lLvf7/Tp//rxqamrCngVVVVXJ7/e7fd5+++2w8VqPkmvt015iYqISExO7U2qnCCAAsCemZ0DGGBUUFGjbtm3avXu3Jk2aFNY+Z84cDRs2TCUlJe6yw4cP69ixY8rKypIkZWVl6cMPP1R1dbXbZ9euXfJ6vZo2bdrl7EvM+DkGALAnpmdA+fn52rJli15//XWNGTPGfc/G5/NpxIgR8vl8WrFihQoLC5WcnCyv16sHHnhAWVlZuuWWWyRJCxYs0LRp0/S9731PTz31lAKBgB599FHl5+f3yrOczvAeEADYE1MAbdiwQZJ0xx13hC3ftGmTli9fLkn61a9+JY/Ho8WLF6uhoUE5OTl6/vnn3b5DhgzRjh07tHr1amVlZWnUqFFatmyZnnjiicvbk27gq3gAwJ6YAqgrHxkaPny4iouLVVxcHLXPxIkT9cc//jGWTfcK3gMCAHv4LjgAgBVxHUA8AwIAewggAIAV3foc0GAxedwojR2dIGMkowvvcRlJanf5Qru58LclsyK26WK7wpa16duVbbjtkccAgMEgrgNo6w++bruEy2JMlJBrCS4pUkC2CbJLhJxpScnIQdvFbbQL5w5B3tVa24/Tbn8j1Xlhrfahf3H7Xa5VFw/AiTy/UbYRYRxFeDBijDRuTN9+BAHoD+I6gAY6x3HkOO4lm6UAQMzi+j0gAIA9BBAAwIq4fglu33+e0tpXP7RdBtDnfvv9uZqW3v0fcwR6QlwH0LnGZv2t5ivbZQB9rrGZ36OHfbwEBwCwggACAFhBAAEArCCAAABWEEAAACsIIACAFQQQAMAKAggAYAUBBACwggACAFhBAAEArCCAAABWEEAAACsIIACAFQQQAMAKAggAYAUBBACwggACAFhBAAEArCCAAABWEEAAACsIIACAFQQQAMAKAggAYAUBBACwggACAFhBAAEArCCAAABWEEAAACsIIACAFQQQAMAKAggAYAUBBACwggACAFhBAAEArCCAAABWEEAAACsIIACAFQQQAMAKAggAYMVQ2wXYNCVtjB7JnWq7DKDPjfcNt10CEN8BNClllFbfcY3tMgAgLsV1AEnSmfrzkiRHkuOo5bwjOW0vS07LhdZ+jlouOxfHal3efj2nbXvbFQAgjsV9AN34P3dZ2/aFwGo93y6odLGxfThGXC9SWDqRw9MdKWycyOEZVmu7Gtr2azNsh9oirRdxn9sF+8Ux248TZb7abD9irU7kGtrOTbTa1WGf29Xa/sFL1DkI36ai7HOH66PNlXzxeg3fx7bbVLRx2q7X4bYT+TYRVluE21LE9Voa//HacZp+pU9AJHEfQDYZI5m2F8Jb+7gaoOd5hw8lgBAVR8EBAKwggAAAVhBAAAArYg6gffv26c4771R6erocx9Frr70W1r58+fILb262OeXm5ob1OXPmjJYuXSqv16ukpCStWLFCZ8+evawdAQAMLDEHUH19vWbNmqXi4uKofXJzc3Xy5En39NJLL4W1L126VIcOHdKuXbu0Y8cO7du3T6tWrYq9egDAgBXzUXB5eXnKy8vrtE9iYqL8fn/Etk8++UQ7d+7UO++8o7lz50qSnnvuOS1cuFC/+MUvlJ6eHmtJAIABqFfeA9q7d69SU1N13XXXafXq1Tp9+rTbVlZWpqSkJDd8JCk7O1sej0cHDhyIOF5DQ4OCwWDYCQAwsPV4AOXm5uqFF15QSUmJnnzySZWWliovL0/Nzc2SpEAgoNTU1LB1hg4dquTkZAUCgYhjFhUVyefzuacJEyb0dNkAgD7W4x9EXbJkiXt+xowZmjlzpq655hrt3btX8+fP79aYa9euVWFhoXs5GAwSQgAwwPX6YdiTJ09WSkqKjhw5Ikny+/2qrq4O69PU1KQzZ85Efd8oMTFRXq837AQAGNh6PYBOnDih06dPa/z48ZKkrKws1dTUqLy83O2ze/duhUIhZWZm9nY5AIB+IuaX4M6ePes+m5GkiooKffDBB0pOTlZycrIef/xxLV68WH6/X0ePHtWPf/xj/cM//INycnIkSddff71yc3O1cuVKbdy4UY2NjSooKNCSJUs4Ag4A4kjMz4DeffddzZ49W7Nnz5YkFRYWavbs2Vq3bp2GDBmigwcP6tvf/rauvfZarVixQnPmzNFf/vIXJSYmumO8+OKLmjp1qubPn6+FCxfq1ltv1W9+85ue2ysAQL8X8zOgO+64Q6bDNzdf9Kc//emSYyQnJ2vLli2xbhoAMIjwXXAAACsIIACAFQQQAMAKAggAYAUBBACwggACAFhBAAEArCCAAABWEEAAACsIIACAFQQQAMAKAggAYAUBBACwggACAFhBAAEArCCAAABWEEAAACsIIACAFQQQAMAKAggAYAUBBACwggACAFhBAAEArCCAAABWEEAAACsIIACAFQQQAMCKobYLsO3B7GttlwAMWjOvSrJdAvqxuA+g/5E9xXYJABCX4j6AzjU2qylk3MtOmzanzQWnTUvb5W21Xx5tnfBtOFGWR+4DAINF3AdQwZb39edPqmyX0W2XFWyKvHK0/u3XiXXb0bcRPdxj3Sd1qb62y8M32JV9itq/iw9YemyuotXRyT6FL+/Kg5/I40abp/aN0WuMsY72W4kw1uN33aCpfm/7atCPxX0ADXTGtDkfrSH62j1cDWBP3bkm2yUgRhwFBwCwggACAFhBAAEArCCAAABWEEAAACsIIACAFQQQAMAKAggAYAUBBACwggACAFhBAAEArCCAAABWEEAAACsIIACAFQQQAMAKAggAYAUBBACwggACAFhBAAEArCCAAABWEEAAACsIIACAFUNtF2BbRvJITb/Sa7sMAJdpxLAhtktAjOI+gNbdOc12CQAQl3gJDgBgRdw/A5Kkfz94UtV15+RIchxHjiM5kuQ4LcskT5vzji50aO3vcS4ud5wLYzpR1pUujt9+3bZjtl9XbcZvv277MduuK4XX1nq+s3U9Ttv9CB+zdd1I9bSuK3c7HddtW0PEPq0bBjDoEUCSNv21Qu9+/nfbZaDF5YRXpOVSxwcJrX0kyeOJPKYiPPBo/wCj/bpde9DSEuSeyGN2/qAlfN3YHrS0fXDRccyoD1rarBtpzIvXTYTrq8N105V1I1yXUdZtvY7Gjk7QN65L7cFbIfpCzAG0b98+Pf300yovL9fJkye1bds23X333W67MUbr16/Xb3/7W9XU1GjevHnasGGDpkyZ4vY5c+aMHnjgAW3fvl0ej0eLFy/Wr3/9a40ePbpHdgoDmzGSaT1zcamlajAQ3JiRRAANQDG/B1RfX69Zs2apuLg4YvtTTz2lZ599Vhs3btSBAwc0atQo5eTk6Ny5c26fpUuX6tChQ9q1a5d27Nihffv2adWqVd3fCwDAgBPzM6C8vDzl5eVFbDPG6JlnntGjjz6qu+66S5L0wgsvKC0tTa+99pqWLFmiTz75RDt37tQ777yjuXPnSpKee+45LVy4UL/4xS+Unp5+GbsDABgoevQouIqKCgUCAWVnZ7vLfD6fMjMzVVZWJkkqKytTUlKSGz6SlJ2dLY/HowMHDkQct6GhQcFgMOwEABjYejSAAoGAJCktLS1seVpamtsWCASUmhr+Wu3QoUOVnJzs9mmvqKhIPp/PPU2YMKEnywYAWDAgPge0du1a1dbWuqfjx4/bLgkAcJl6NID8fr8kqaqqKmx5VVWV2+b3+1VdXR3W3tTUpDNnzrh92ktMTJTX6w07AQAGth4NoEmTJsnv96ukpMRdFgwGdeDAAWVlZUmSsrKyVFNTo/LycrfP7t27FQqFlJmZ2ZPlAAD6sZiPgjt79qyOHDniXq6oqNAHH3yg5ORkZWRkaM2aNfrpT3+qKVOmaNKkSfrJT36i9PR097NC119/vXJzc7Vy5Upt3LhRjY2NKigo0JIlSzgCDgDiSMwB9O677+ob3/iGe7mwsFCStGzZMm3evFk//vGPVV9fr1WrVqmmpka33nqrdu7cqeHDh7vrvPjiiyooKND8+fPdD6I+++yzPbA7AICBwjHGDLiPmAeDQfl8PtXW1vbI+0Hf3fAWX8UDDGA3ZiTp1R/Os10GFNv/5wFxFBwAYPAhgAAAVhBAAAArCCAAgBUEEADACgIIAGAFAQQAsIIAAgBYQQABAKwggAAAVhBAAAArYv4y0sFoUsoofdXYbLsMAN00KWW07RLQDQSQpKf/2yzbJQBA3OElOACAFQQQAMCKuH4J7q2jX+iJ7R+HLXMcR457vt1fOW3OX+zUoX9nY+lip0htkbbZ9nLruOHbCd9ma9vFdcLHcBR9/Atjhe+IE2Wb0doUaX+6sK/qav92+9q+X8c5Ce/vtKux4/5EH0sR577jGG5b2yuuK/0jXN+ttXc69126XXYyN21ukJ3dlrp6u4x6+wpbJ1JbhPmNcN/prH9r345z0tncR7/tRbpdehxHsyYkCZcnrgPo7LkmfRqos10GgAFmqMfRkZ8ttF3GgMdLcAAAKwggAIAVBBAAwAoCCABgBQEEALCCAAIAWEEAAQCsIIAAAFYQQAAAKwggAIAVBBAAwAoCCABgBQEEALCCAAIAWEEAAQCsIIAAAFYQQAAAKwggAIAVBBAAwAoCCABgBQEEALCCAAIAWEEAAQCsIIAAAFYQQAAAKwggAIAVBBAAwAoCCABgBQEEALCCAAIAWDHUdgE2pYxJ1DenptouA8AA43Ec2yUMCnEdQDdmXKHfLb/JdhkAEJd4CQ4AYEVcPwOqb2hSY3NIkuSozVPqtmedDovktCwMX9baz+mwTDH0c9xlToRlHWsAgIEqrgPosf97SFvLT9guo8d0FpZtl4cHXseVOusXKSzbbicsFjsL726EriKEdlcfBESbk/b9ujNOl/c52vYizG2kWiM/EIlea9g2L3k76OL2Orm9XKqey9nn8LE79o08t92/vURrj/X6vdR9UZeYE0fSlVeM0JrsazUYxXUADTbGtPyNtDD6Wr1UDYCeMP1K76ANIN4DAgBYQQABAKwggAAAVhBAAAArCCAAgBU9HkCPPfaYHMcJO02dOtVtP3funPLz8zV27FiNHj1aixcvVlVVVU+XAQDo53rlGdANN9ygkydPuqc333zTbXvwwQe1fft2bd26VaWlpaqsrNQ999zTG2UAAPqxXvkc0NChQ+X3+zssr62t1b/9279py5Yt+uY3vylJ2rRpk66//nrt379ft9xyS2+UAwDoh3rlGdBnn32m9PR0TZ48WUuXLtWxY8ckSeXl5WpsbFR2drbbd+rUqcrIyFBZWVnU8RoaGhQMBsNOAICBrccDKDMzU5s3b9bOnTu1YcMGVVRU6LbbblNdXZ0CgYASEhKUlJQUtk5aWpoCgUDUMYuKiuTz+dzThAkTerpsAEAf6/GX4PLy8tzzM2fOVGZmpiZOnKhXXnlFI0aM6NaYa9euVWFhoXs5GAwSQgAwwPX6YdhJSUm69tprdeTIEfn9fp0/f141NTVhfaqqqiK+Z9QqMTFRXq837AQAGNh6PYDOnj2ro0ePavz48ZozZ46GDRumkpISt/3w4cM6duyYsrKyersUAEA/0uMvwf3oRz/SnXfeqYkTJ6qyslLr16/XkCFDdN9998nn82nFihUqLCxUcnKyvF6vHnjgAWVlZXEEHADEmR4PoBMnTui+++7T6dOnNW7cON16663av3+/xo0bJ0n61a9+JY/Ho8WLF6uhoUE5OTl6/vnne7oMAEA/1+MB9PLLL3faPnz4cBUXF6u4uLinNw0AGED4LjgAgBUEEADACgIIAGAFAQQAsIIAAgBYQQABAKzolZ9jGChGJAyRd3hcTwGAfm5UwuD9H+UYY4ztImIVDAbl8/lUW1vL98IBQD8Sy//nwRutl3Di71/qVF2DhngceZyWk0ca4jjytCwb0rLM4zga4nHkOBfaL5x3Wta92H5hHMlxHNu7BwD9XtwG0P8u+1z/a9//65WxW0PJ0xJQYaHWJqjc863B19JviNMSdp62yxTW3hqMEcd0AzTyOmGhG7aOWrZ9oU/E0HXUbl/ajRlxn8NrjRTk7fe5/ToR63McOWFzFz6PAPq3uA2g3hQyUsiYC2dgTduADAtMN5C7GLodwv5SoauwkI82ZtvthtXVxSCPtE7bPl0Oco9aHly0qbVd/R33WW1eJYi8z7wagEshgDBoNYeMmiVJPBCwpTV4uxpareHX4VWAqKEb3idiEHYIXbV5Rh/pQUmUIA97af7iti6GdxeDvF39UV8ZaVk+YtgQZYwdafuq7BUEEIBeY4zUZIwko5ZHA4jRDele/ft/v812Gb2CzwEBAKwggAAAVhBAAAArCCAAgBUEEADACgIIAGAFAQQAsIIAAgBYQQABAKwggAAAVhBAAAArCCAAgBUEEADACgIIAGAFAQQAsIIAAgBYQQABAKwggAAAVhBAAAArCCAAgBUEEADAiqG2C7AlZ7pfE8eOsl0GAHTqipHDbJfQa+I2gG7MuEI3ZlxhuwwAiFtxG0CS9HbFGf3ls1OSJGMuLje6eKHt8gttitjWdp0oZ2XM5Y3bfp2I40YZp7Oxoq8Tpf9ljtuVubqwzqX3K+r8hhcYedvtx+rCvHdlrrpTY1f6t9elemPcp/YLujYPXb39RW6M9bbf+X0n8nzFft22uz6jXIj9uu3a7S+8z2WOG2V5tPv3rVNS9OslsyMX08PiOoDeO/Z3Pbf7iO0yAKDfqDvX1Gfb4iAEAIAVBBAAwAoCCABgBQEEALCCAAIAWEEAAQCsIIAAAFYQQAAAKwggAIAVBBAAwAoCCABgBQEEALCCAAIAWEEAAQCsIIAAAFYQQAAAKwggAIAVBBAAwAoCCABgBQEEALDCagAVFxfr6quv1vDhw5WZmam3337bZjkAgD5kLYD+8Ic/qLCwUOvXr9d7772nWbNmKScnR9XV1bZKAgD0IWsB9Mtf/lIrV67U/fffr2nTpmnjxo0aOXKkfve739kqCQDQh6wE0Pnz51VeXq7s7OyLhXg8ys7OVllZWYf+DQ0NCgaDYScAwMA21MZGv/jiCzU3NystLS1seVpamj799NMO/YuKivT444/3eB03XZ2sh3Ou6/FxAWCgmjh2ZJ9ty0oAxWrt2rUqLCx0LweDQU2YMOGyx50z8QrNmXjFZY8DAIidlQBKSUnRkCFDVFVVFba8qqpKfr+/Q//ExEQlJib2VXkAgD5g5T2ghIQEzZkzRyUlJe6yUCikkpISZWVl2SgJANDHrL0EV1hYqGXLlmnu3Lm6+eab9cwzz6i+vl7333+/rZIAAH3IWgDde++9OnXqlNatW6dAIKCvfe1r2rlzZ4cDEwAAg5NjjDG2i4hVMBiUz+dTbW2tvF6v7XIAAC1i+f/Md8EBAKwggAAAVhBAAAArCCAAgBUEEADACgIIAGAFAQQAsIIAAgBYQQABAKwYED/H0F7rlzfww3QA0L+0/l/uypfsDMgAqqurk6Qe+U0gAEDPq6urk8/n67TPgPwuuFAopMrKSo0ZM0aO48S8fusP2h0/fpzvkmuDeemIOYmMeemIObnAGKO6ujqlp6fL4+n8XZ4B+QzI4/HoqquuuuxxvF5vXN9QomFeOmJOImNeOmJOdMlnPq04CAEAYAUBBACwIi4DKDExUevXr1diYqLtUvoV5qUj5iQy5qUj5iR2A/IgBADAwBeXz4AAAPYRQAAAKwggAIAVBBAAwIq4DKDi4mJdffXVGj58uDIzM/X222/bLqnPPPbYY3IcJ+w0depUt/3cuXPKz8/X2LFjNXr0aC1evFhVVVUWK+4d+/bt05133qn09HQ5jqPXXnstrN0Yo3Xr1mn8+PEaMWKEsrOz9dlnn4X1OXPmjJYuXSqv16ukpCStWLFCZ8+e7cO96FmXmpPly5d3uO3k5uaG9Rlsc1JUVKSbbrpJY8aMUWpqqu6++24dPnw4rE9X7jPHjh3TokWLNHLkSKWmpurhhx9WU1NTX+5KvxR3AfSHP/xBhYWFWr9+vd577z3NmjVLOTk5qq6utl1an7nhhht08uRJ9/Tmm2+6bQ8++KC2b9+urVu3qrS0VJWVlbrnnnssVts76uvrNWvWLBUXF0dsf+qpp/Tss89q48aNOnDggEaNGqWcnBydO3fO7bN06VIdOnRIu3bt0o4dO7Rv3z6tWrWqr3ahx11qTiQpNzc37Lbz0ksvhbUPtjkpLS1Vfn6+9u/fr127dqmxsVELFixQfX292+dS95nm5mYtWrRI58+f11tvvaXf//732rx5s9atW2djl/oXE2duvvlmk5+f715ubm426enppqioyGJVfWf9+vVm1qxZEdtqamrMsGHDzNatW91ln3zyiZFkysrK+qjCvifJbNu2zb0cCoWM3+83Tz/9tLuspqbGJCYmmpdeeskYY8zHH39sJJl33nnH7fPGG28Yx3HM3/72tz6rvbe0nxNjjFm2bJm56667oq4z2OfEGGOqq6uNJFNaWmqM6dp95o9//KPxeDwmEAi4fTZs2GC8Xq9paGjo2x3oZ+LqGdD58+dVXl6u7Oxsd5nH41F2drbKysosVta3PvvsM6Wnp2vy5MlaunSpjh07JkkqLy9XY2Nj2PxMnTpVGRkZcTU/FRUVCgQCYfPg8/mUmZnpzkNZWZmSkpI0d+5ct092drY8Ho8OHDjQ5zX3lb179yo1NVXXXXedVq9erdOnT7tt8TAntbW1kqTk5GRJXbvPlJWVacaMGUpLS3P75OTkKBgM6tChQ31Yff8TVwH0xRdfqLm5OeyGIElpaWkKBAKWqupbmZmZ2rx5s3bu3KkNGzaooqJCt912m+rq6hQIBJSQkKCkpKSwdeJpfiS5+9rZ7SQQCCg1NTWsfejQoUpOTh60c5Wbm6sXXnhBJSUlevLJJ1VaWqq8vDw1NzdLGvxzEgqFtGbNGs2bN0/Tp0+XpC7dZwKBQMTbUmtbPBuQ34aN7svLy3PPz5w5U5mZmZo4caJeeeUVjRgxwmJl6O+WLFninp8xY4Zmzpypa665Rnv37tX8+fMtVtY38vPz9dFHH4W9Z4rLE1fPgFJSUjRkyJAOR6hUVVXJ7/dbqsqupKQkXXvttTpy5Ij8fr/Onz+vmpqasD7xNj+t+9rZ7cTv93c4cKWpqUlnzpyJm7maPHmyUlJSdOTIEUmDe04KCgq0Y8cO7dmzJ+ynYLpyn/H7/RFvS61t8SyuAighIUFz5sxRSUmJuywUCqmkpERZWVkWK7Pn7NmzOnr0qMaPH685c+Zo2LBhYfNz+PBhHTt2LK7mZ9KkSfL7/WHzEAwGdeDAAXcesrKyVFNTo/LycrfP7t27FQqFlJmZ2ec123DixAmdPn1a48ePlzQ458QYo4KCAm3btk27d+/WpEmTwtq7cp/JysrShx9+GBbOu3btktfr1bRp0/pmR/or20dB9LWXX37ZJCYmms2bN5uPP/7YrFq1yiQlJYUdoTKYPfTQQ2bv3r2moqLC/PWvfzXZ2dkmJSXFVFdXG2OM+cEPfmAyMjLM7t27zbvvvmuysrJMVlaW5ap7Xl1dnXn//ffN+++/bySZX/7yl+b99983n3/+uTHGmJ///OcmKSnJvP766+bgwYPmrrvuMpMmTTJfffWVO0Zubq6ZPXu2OXDggHnzzTfNlClTzH333Wdrly5bZ3NSV1dnfvSjH5mysjJTUVFh/vznP5sbb7zRTJkyxZw7d84dY7DNyerVq43P5zN79+41J0+edE9ffvml2+dS95mmpiYzffp0s2DBAvPBBx+YnTt3mnHjxpm1a9fa2KV+Je4CyBhjnnvuOZORkWESEhLMzTffbPbv32+7pD5z7733mvHjx5uEhARz5ZVXmnvvvdccOXLEbf/qq6/MD3/4Q3PFFVeYkSNHmu985zvm5MmTFivuHXv27DGSOpyWLVtmjLlwKPZPfvITk5aWZhITE838+fPN4cOHw8Y4ffq0ue+++8zo0aON1+s1999/v6mrq7OwNz2jszn58ssvzYIFC8y4cePMsGHDzMSJE83KlSs7PHAbbHMSaT4kmU2bNrl9unKf+a//+i+Tl5dnRowYYVJSUsxDDz1kGhsb+3hv+h9+jgEAYEVcvQcEAOg/CCAAgBUEEADACgIIAGAFAQQAsIIAAgBYQQABAKwggAAAVhBAAAArCCAAgBUEEADACgIIAGDF/wcNtM4g4ZonawAAAABJRU5ErkJggg=="
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
     }
    ],
-   "execution_count": 5
+   "source": [
+    "data_utm.loc[data_utm['asset_type']=='combiner'].plot(aspect='equal')"
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "And write the results to a new GeoJSON file that uses meters relative to the plant corner for coordinates. The location of the plant is now anonymized."
+   "source": [
+    "And write the results to a new GeoJSON file that uses meters relative to the plant corner for coordinates. The location of the plant is now anonymized."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-05-15T23:19:07.432130Z",
      "start_time": "2024-05-15T23:19:07.402131Z"
     }
    },
-   "source": [
-    "# Write new file\n",
-    "data_utm.to_file('data/digitized_plant_meters.geojson', driver='GeoJSON') \n",
-    "data_utm.head()"
-   ],
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "     id asset_type  asset_name  \\\n",
-       "0  None   combiner  CMB-001-01   \n",
-       "1  None   combiner  CMB-001-02   \n",
-       "2  None   combiner  CMB-001-03   \n",
-       "3  None   combiner  CMB-001-04   \n",
-       "4  None   combiner  CMB-001-05   \n",
-       "\n",
-       "                                            geometry  \n",
-       "0  MULTIPOLYGON (((99.546 241.961, 99.546 224.268...  \n",
-       "1  MULTIPOLYGON (((118.433 222.720, 118.433 191.7...  \n",
-       "2  MULTIPOLYGON (((138.209 189.103, 138.210 158.5...  \n",
-       "3  MULTIPOLYGON (((157.097 156.370, 157.097 125.4...  \n",
-       "4  MULTIPOLYGON (((176.429 123.416, 176.429 105.7...  "
-      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -382,6 +371,21 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
+      ],
+      "text/plain": [
+       "     id asset_type  asset_name  \\\n",
+       "0  None   combiner  CMB-001-01   \n",
+       "1  None   combiner  CMB-001-02   \n",
+       "2  None   combiner  CMB-001-03   \n",
+       "3  None   combiner  CMB-001-04   \n",
+       "4  None   combiner  CMB-001-05   \n",
+       "\n",
+       "                                            geometry  \n",
+       "0  MULTIPOLYGON (((99.546 241.961, 99.546 224.268...  \n",
+       "1  MULTIPOLYGON (((118.433 222.720, 118.433 191.7...  \n",
+       "2  MULTIPOLYGON (((138.209 189.103, 138.210 158.5...  \n",
+       "3  MULTIPOLYGON (((157.097 156.370, 157.097 125.4...  \n",
+       "4  MULTIPOLYGON (((176.429 123.416, 176.429 105.7...  "
       ]
      },
      "execution_count": 6,
@@ -389,42 +393,34 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 6
+   "source": [
+    "# Write new file\n",
+    "data_utm.to_file('data/digitized_plant_meters.geojson', driver='GeoJSON') \n",
+    "data_utm.head()"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Exporting Data for Use by solartoolbox\n",
     "The data is now converted to a relative rectilinear coordinate system. One data item that we frequently need for analyses (e.g. `field`) is the centroid of these positions. We can extract that data and save it to a convenient format, like CSV or h5. \n",
     "\n",
-    "Since the shapes in the GeoJSON file are polygons, we can get the centroid of each shape using the `centroid` attribute. We will store this in a standard pandas DataFrame, indexed by the `asset_name` field that we created."
+    "Since the shapes in the GeoJSON file are polygons, we can get the centroid of each shape using the `centroid` attribute. We will store this in a standard pandas DataFrame, indexed by the `asset_name` field that we created. We will also filter on `asset_type` of `combiner`, so that we don't include centroids of other assets that may have been digitized."
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-05-15T23:19:07.447130Z",
      "start_time": "2024-05-15T23:19:07.433132Z"
     }
    },
-   "cell_type": "code",
-   "source": [
-    "data_centroids = pd.DataFrame(data_utm.centroid.get_coordinates().values, index=data_utm.asset_name, columns=['E', 'N'])\n",
-    "data_centroids.head()"
-   ],
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "                    E           N\n",
-       "asset_name                       \n",
-       "CMB-001-01  76.504393  232.462541\n",
-       "CMB-001-02  63.430049  206.657679\n",
-       "CMB-001-03  69.549150  173.841325\n",
-       "CMB-001-04  78.919717  140.997993\n",
-       "CMB-001-05  88.699994  114.623431"
-      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -482,6 +478,15 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
+      ],
+      "text/plain": [
+       "                    E           N\n",
+       "asset_name                       \n",
+       "CMB-001-01  76.504393  232.462541\n",
+       "CMB-001-02  63.430049  206.657679\n",
+       "CMB-001-03  69.549150  173.841325\n",
+       "CMB-001-04  78.919717  140.997993\n",
+       "CMB-001-05  88.699994  114.623431"
       ]
      },
      "execution_count": 7,
@@ -489,27 +494,36 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 7
+   "source": [
+    "data_boundaries = data_utm.loc[data_utm['asset_type']=='combiner']\n",
+    "data_centroids = pd.DataFrame(\n",
+    "    data_boundaries.centroid.get_coordinates().values,\n",
+    "    index=data_utm.asset_name, columns=['E', 'N']\n",
+    "    )\n",
+    "data_centroids.head()"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "You could now save the data as desired. Examples of CSV and h5 formats are shown below."
+   "metadata": {},
+   "source": [
+    "You could now save the data as desired. Examples of CSV and h5 formats are shown below."
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-05-15T23:19:09.259074Z",
      "start_time": "2024-05-15T23:19:07.449134Z"
     }
    },
-   "cell_type": "code",
+   "outputs": [],
    "source": [
     "data_centroids.to_csv(f'data/digitized_plant_centroids.csv')\n",
     "data_centroids.to_hdf(f'data/digitized_plant_centroids.h5', key='utm', mode='a', append=True)"
-   ],
-   "outputs": [],
-   "execution_count": 8
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
I added a filter in the second to last code block to only grab combiners. There are no `asset_type` = `inverter` in the sample geojson file, but I talked about the option to add them, so I think it makes sense to filter on `asset_type`, just in case someone builds off of the demo. 

changed this:
```python
data_centroids = pd.DataFrame(data_utm.centroid.get_coordinates().values, index=data_utm.asset_name, columns=['E', 'N'])
data_centroids.head()
```
to this:
```python
data_boundaries = data_utm.loc[data_utm['asset_type']=='combiner']
data_centroids = pd.DataFrame(
    data_boundaries.centroid.get_coordinates().values,
    index=data_utm.asset_name, columns=['E', 'N']
    )
data_centroids.head()
```